### PR TITLE
Unify concurrent and non-concurrent verification with ability to control concurrency

### DIFF
--- a/substrate/client/consensus/common/Cargo.toml
+++ b/substrate/client/consensus/common/Cargo.toml
@@ -32,7 +32,7 @@ sp-consensus = { path = "../../../primitives/consensus/common" }
 sp-core = { path = "../../../primitives/core" }
 sp-runtime = { path = "../../../primitives/runtime" }
 sp-state-machine = { path = "../../../primitives/state-machine" }
-tokio = "1.32.0"
+tokio = { version = "1.32.0", features = ["macros"] }
 
 [dev-dependencies]
 sp-test-primitives = { path = "../../../primitives/test-primitives" }


### PR DESCRIPTION
This backports last commit of https://github.com/paritytech/polkadot-sdk/pull/1598 that allows us to tweak verification concurrency rather than spawning as many threads as there are blocks in the queue, which can be thousands.