### PR TITLE
Storage metering

### DIFF
--- a/polkadot/node/core/pvf/common/src/executor_intf.rs
+++ b/polkadot/node/core/pvf/common/src/executor_intf.rs
@@ -291,6 +291,10 @@ impl sp_externalities::Externalities for ValidationExternalities {
 		panic!("storage_commit_transaction: unsupported feature for parachain validation")
 	}
 
+    fn transaction_storage_size(&mut self) -> u64 {
+		panic!("storage_commit_transaction: unsupported feature for parachain validation")
+    }
+
 	fn wipe(&mut self) {
 		panic!("wipe: unsupported feature for parachain validation")
 	}

--- a/substrate/primitives/externalities/src/lib.rs
+++ b/substrate/primitives/externalities/src/lib.rs
@@ -239,6 +239,9 @@ pub trait Externalities: ExtensionStore {
 	/// no transaction is open that can be closed.
 	fn storage_commit_transaction(&mut self) -> Result<(), ()>;
 
+	/// Get the total storage used by the current transaction.
+	fn transaction_storage_size(&mut self) -> u64;
+
 	/// Index specified transaction slice and store it.
 	fn storage_index_transaction(&mut self, _index: u32, _hash: &[u8], _size: u32) {
 		unimplemented!("storage_index_transaction");

--- a/substrate/primitives/io/src/lib.rs
+++ b/substrate/primitives/io/src/lib.rs
@@ -367,6 +367,11 @@ pub trait Storage {
 		self.storage_commit_transaction()
 			.expect("No open transaction that can be committed.");
 	}
+
+	/// Get the total storage used by the current transaction.
+	fn transaction_storage_size(&mut self) -> u64 {
+		self.transaction_storage_size()
+	}
 }
 
 /// Interface for accessing the child storage for default child trie,

--- a/substrate/primitives/state-machine/src/basic.rs
+++ b/substrate/primitives/state-machine/src/basic.rs
@@ -303,6 +303,10 @@ impl Externalities for BasicExternalities {
 		self.overlay.commit_transaction().map_err(drop)
 	}
 
+	fn transaction_storage_size(&mut self) -> u64 {
+		self.overlay.transaction_storage_size()
+	}
+
 	fn wipe(&mut self) {}
 
 	fn commit(&mut self) {}

--- a/substrate/primitives/state-machine/src/ext.rs
+++ b/substrate/primitives/state-machine/src/ext.rs
@@ -592,6 +592,10 @@ where
 		self.overlay.commit_transaction().map_err(|_| ())
 	}
 
+	fn transaction_storage_size(&mut self) -> u64 {
+		self.overlay.transaction_storage_size()
+	}
+
 	fn wipe(&mut self) {
 		for _ in 0..self.overlay.transaction_depth() {
 			self.overlay.rollback_transaction().expect(BENCHMARKING_FN);

--- a/substrate/primitives/state-machine/src/overlayed_changes/mod.rs
+++ b/substrate/primitives/state-machine/src/overlayed_changes/mod.rs
@@ -478,6 +478,15 @@ impl<H: Hasher> OverlayedChanges<H> {
 		Ok(())
 	}
 
+	/// Get the total storage used by the current transaction.
+	pub fn transaction_storage_size(&mut self) -> u64 {
+		let mut total = 0;
+		for (_, overlayed_value) in self.changes() {
+			total += overlayed_value.value().map_or(0, |v| v.len() as u64)
+		}
+		total
+	}
+
 	/// Call this before transfering control to the runtime.
 	///
 	/// This protects all existing transactions from being removed by the runtime.

--- a/substrate/primitives/state-machine/src/read_only.rs
+++ b/substrate/primitives/state-machine/src/read_only.rs
@@ -195,6 +195,10 @@ where
 		unimplemented!("Transactions are not supported by ReadOnlyExternalities");
 	}
 
+	fn transaction_storage_size(&mut self) -> u64 {
+		unimplemented!("Transactions are not supported by ReadOnlyExternalities");
+	}
+
 	fn wipe(&mut self) {}
 
 	fn commit(&mut self) {}


### PR DESCRIPTION
Context: https://github.com/paritytech/polkadot-sdk/issues/2166

This change implements the proposal 1 in 2166 (rollback transaction if cost exceeds threshold).
Next:
1. The limit is hardcoded now, working on plumbing as part of config
2. Include meta info about the transaction in the block when threshold is exceeded, instead of completely discarding the transaction