### PR TITLE
Add function to get recorded keys from proof recorder instance

### DIFF
--- a/substrate/primitives/trie/src/recorder.rs
+++ b/substrate/primitives/trie/src/recorder.rs
@@ -105,6 +105,15 @@ impl<H: Hasher> Clone for Recorder<H> {
 }
 
 impl<H: Hasher> Recorder<H> {
+	/// Keys for which we have recorded the trie nodes till now.
+	/// Note that this does not modify the internals, rather returns snapshot of the recorded keys.
+	/// There can be multiple storage root in case we are tracking more than one tries.
+	pub fn recorded_keys(&self) -> HashMap<<H as Hasher>::Out, HashMap<Arc<[u8]>, RecordedForKey>> {
+		let inner = self.inner.lock();
+		inner.recorded_keys.clone()
+	}
+
+
 	/// Returns the recorder as [`TrieRecorder`](trie_db::TrieRecorder) compatible type.
 	///
 	/// - `storage_root`: The storage root of the trie for which accesses are recorded. This is


### PR DESCRIPTION
# Description

*Please include a summary of the changes and the related issue. Please also include relevant motivation and context,
including:*

- What does this PR do?
This PR adds function to get recorded keys from proof recorder instance
- Why are these changes needed?
This change is required to get the keys accessed by the trie backend during the runtime execution. The keys are already tracked by proof recorder, just isn't exposed publicly.
- How were these changes implemented and what do they affect?
The changes are implemented by adding a public function in proof recorder that simply clones the `recorded_keys` field.

@nazar-pc I am not sure if this can be upstreamed. Since this change is specific to our use case where we want to get the keys accessed instead of directly getting the proof (this functionality is already there.). Please correct me if I am wrong. 
