### PR TITLE
Do not panic if the fdlimit call to increase the file descriptor limit fails (cherrypicked)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4925,11 +4925,12 @@ dependencies = [
 
 [[package]]
 name = "fdlimit"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4c9e43643f5a3be4ca5b67d26b98031ff9db6806c3440ae32e02e3ceac3f1b"
+checksum = "e182f7dbc2ef73d9ef67351c5fbbea084729c48362d3ce9dd44c28e32e277fe5"
 dependencies = [
  "libc",
+ "thiserror",
 ]
 
 [[package]]
@@ -18551,9 +18552,9 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.48"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
@@ -18580,9 +18581,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.48"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/substrate/client/cli/Cargo.toml
+++ b/substrate/client/cli/Cargo.toml
@@ -17,7 +17,7 @@ array-bytes = "6.1"
 atomic = "0.5.3"
 chrono = "0.4.27"
 clap = { version = "4.4.3", features = ["derive", "string"] }
-fdlimit = "0.2.1"
+fdlimit = "0.3.0"
 futures = "0.3.21"
 libp2p-identity = { version = "0.1.3", features = ["peerid", "ed25519"]}
 log = "0.4.17"

--- a/substrate/client/cli/src/config.rs
+++ b/substrate/client/cli/src/config.rs
@@ -614,14 +614,25 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 
 		logger.init()?;
 
-		if let Some(new_limit) = fdlimit::raise_fd_limit() {
-			if new_limit < RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT {
+		match fdlimit::raise_fd_limit() {
+			Ok(fdlimit::Outcome::LimitRaised { to, .. }) =>
+				if to < RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT {
+					warn!(
+						"Low open file descriptor limit configured for the process. \
+						Current value: {:?}, recommended value: {:?}.",
+						to, RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT,
+					);
+				},
+			Ok(fdlimit::Outcome::Unsupported) => {
+				// Unsupported platform (non-Linux)
+			},
+			Err(error) => {
 				warn!(
-					"Low open file descriptor limit configured for the process. \
-					Current value: {:?}, recommended value: {:?}.",
-					new_limit, RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT,
+					"Failed to configure file descriptor limit for the process: \
+					{}, recommended value: {:?}.",
+					error, RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT,
 				);
-			}
+			},
 		}
 
 		Ok(())

--- a/substrate/client/service/test/Cargo.toml
+++ b/substrate/client/service/test/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 async-channel = "1.8.0"
 array-bytes = "6.1"
-fdlimit = "0.2.1"
+fdlimit = "0.3.0"
 futures = "0.3.21"
 log = "0.4.17"
 parity-scale-codec = "3.6.1"

--- a/substrate/client/service/test/src/lib.rs
+++ b/substrate/client/service/test/src/lib.rs
@@ -286,7 +286,7 @@ where
 		base_port: u16,
 	) -> TestNet<G, E, F, U> {
 		sp_tracing::try_init_simple();
-		fdlimit::raise_fd_limit();
+		fdlimit::raise_fd_limit().unwrap();
 		let runtime = Runtime::new().expect("Error creating tokio runtime");
 		let mut net = TestNet {
 			runtime,


### PR DESCRIPTION
This PR contains commit cherry-picked https://github.com/paritytech/polkadot-sdk/commit/079b14f624bef9dd901f93c29424cba0ebbd325d from upstream. The description below is copied from the PR as is.

# Description

Sometimes changing file descriptor limits is not allowed, but there is no need to crash the node if/when this happens. Since `fdlimit`'s author decided to use panics instead of returning `Result`, we need to catch it.

- [x] My PR includes a detailed description as outlined in the "Description" section above
- [ ] My PR follows the [labeling requirements](CONTRIBUTING.md#Process) of this project (at minimum one label for `T`
  required)
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

