### PR TITLE
add `peer_store_handler` field in NetworkService struct initializer

### DIFF
--- a/substrate/client/network/src/service.rs
+++ b/substrate/client/network/src/service.rs
@@ -527,6 +527,7 @@ where
 			notification_protocol_ids,
 			protocol_handles,
 			sync_protocol_handle,
+			peer_store_handle: params.peer_store.clone(),
 			_marker: PhantomData,
 			_block: Default::default(),
 		});


### PR DESCRIPTION
# Description
This PR adds missing `peer_store_handler` field in `NetworkService` struct initializer. The order in struct field is copied from polkadot-sdk.