### PR TITLE
Support fast-sync algorithm.

### DIFF
--- a/substrate/client/api/src/in_mem.rs
+++ b/substrate/client/api/src/in_mem.rs
@@ -447,6 +447,14 @@ impl<Block: BlockT> blockchain::Backend<Block> for Blockchain<Block> {
 	) -> sp_blockchain::Result<Option<Vec<Vec<u8>>>> {
 		unimplemented!("Not supported by the in-mem backend.")
 	}
+
+	fn clear_block_gap(&self){
+		unimplemented!("Not supported by the in-mem backend.")
+	}
+
+	fn update_block_gap(&self, _: NumberFor<Block>, _: NumberFor<Block>){
+		unimplemented!("Not supported by the in-mem backend.")
+	}
 }
 
 impl<Block: BlockT> backend::AuxStore for Blockchain<Block> {

--- a/substrate/client/db/src/lib.rs
+++ b/substrate/client/db/src/lib.rs
@@ -790,6 +790,16 @@ impl<Block: BlockT> sc_client_api::blockchain::Backend<Block> for BlockchainDb<B
 				Err(sp_blockchain::Error::Backend(format!("Error decoding body list: {}", err))),
 		}
 	}
+
+	fn clear_block_gap(&self) {
+		debug!(target: "sync", "Clear block gap.");
+		self.update_block_gap(None);
+	}
+
+	fn update_block_gap(&self, start: NumberFor<Block>, end: NumberFor<Block>){
+		debug!(target: "sync", "Update block gap: {}-{}", start, end);
+		self.update_block_gap(Some((start, end)));
+	}
 }
 
 impl<Block: BlockT> HeaderMetadata<Block> for BlockchainDb<Block> {
@@ -1761,6 +1771,7 @@ impl<Block: BlockT> Backend<Block> {
 		for m in meta_updates {
 			self.blockchain.update_meta(m);
 		}
+
 		self.blockchain.update_block_gap(block_gap);
 
 		Ok(())

--- a/substrate/client/network/src/service.rs
+++ b/substrate/client/network/src/service.rs
@@ -743,6 +743,21 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 		rx.await.map_err(|_| ())
 	}
 
+	/// Returns a collection of currently connected (open) peers.
+	pub async fn open_peers(&self) -> Result<Vec<PeerId>, ()> {
+		let (tx, rx) = oneshot::channel();
+
+		let _ = self
+			.to_worker
+			.unbounded_send(ServiceToWorkerMsg::OpenPeers { pending_response: tx });
+
+		match rx.await {
+			Ok(v) => Ok(v),
+			// The channel can only be closed if the network worker no longer exists.
+			Err(_) => Err(()),
+		}
+	}
+
 	/// Utility function to extract `PeerId` from each `Multiaddr` for peer set updates.
 	///
 	/// Returns an `Err` if one of the given addresses is invalid or contains an
@@ -1173,6 +1188,9 @@ enum ServiceToWorkerMsg {
 	NetworkState {
 		pending_response: oneshot::Sender<Result<NetworkState, RequestFailure>>,
 	},
+	OpenPeers {
+		pending_response: oneshot::Sender<Vec<PeerId>>,
+	},
 	DisconnectPeer(PeerId, ProtocolName),
 }
 
@@ -1315,7 +1333,14 @@ where
 				.behaviour_mut()
 				.user_protocol_mut()
 				.disconnect_peer(&who, protocol_name),
+			ServiceToWorkerMsg::OpenPeers { pending_response} => {
+				let _ = pending_response.send(self.open_peers());
+			}
 		}
+	}
+
+	fn open_peers(&self) -> Vec<PeerId> {
+		self.network_service.behaviour().user_protocol().open_peers().cloned().collect::<Vec<_>>()
 	}
 
 	/// Process the next event coming from `Swarm`.

--- a/substrate/client/network/sync/src/engine.rs
+++ b/substrate/client/network/sync/src/engine.rs
@@ -1230,6 +1230,7 @@ where
 
 		match Self::encode_state_request(&request) {
 			Ok(data) => {
+				println!("Preparing state request: {}, peer_id={peer_id}", data.len());
 				self.network_service.start_request(
 					peer_id,
 					self.state_request_protocol_name.clone(),
@@ -1286,6 +1287,7 @@ where
 	}
 
 	fn decode_state_response(response: &[u8]) -> Result<OpaqueStateResponse, String> {
+		println!("decode_state_response: {}", response.len());
 		let response = StateResponse::decode(response)
 			.map_err(|error| format!("Failed to decode state response: {error}"))?;
 

--- a/substrate/client/network/sync/src/engine.rs
+++ b/substrate/client/network/sync/src/engine.rs
@@ -102,7 +102,7 @@ const MAX_KNOWN_BLOCKS: usize = 1024; // ~32kb per peer + LruHashSet overhead
 /// If the block announces stream to peer has been inactive for 30 seconds meaning local node
 /// has not sent or received block announcements to/from the peer, report the node for inactivity,
 /// disconnect it and attempt to establish connection to some other peer.
-const INACTIVITY_EVICT_THRESHOLD: Duration = Duration::from_secs(30);
+const INACTIVITY_EVICT_THRESHOLD: Duration = Duration::from_secs(1000);
 
 /// When `SyncingEngine` is started, wait two minutes before actually staring to count peers as
 /// evicted.
@@ -114,7 +114,7 @@ const INACTIVITY_EVICT_THRESHOLD: Duration = Duration::from_secs(30);
 ///
 /// To prevent this from happening, define a threshold for how long `SyncingEngine` should wait
 /// before it starts evicting peers.
-const INITIAL_EVICTION_WAIT_PERIOD: Duration = Duration::from_secs(2 * 60);
+const INITIAL_EVICTION_WAIT_PERIOD: Duration = Duration::from_secs(2 * 600);
 
 /// Maximum allowed size for a block announce.
 const MAX_BLOCK_ANNOUNCE_SIZE: u64 = 1024 * 1024;

--- a/substrate/client/network/sync/src/engine.rs
+++ b/substrate/client/network/sync/src/engine.rs
@@ -839,6 +839,9 @@ where
 			ToServiceCommand::SetSyncForkRequest(peers, hash, number) => {
 				self.strategy.set_sync_fork_request(peers, &hash, number);
 			},
+			ToServiceCommand::NewBestBlockNumber(number) => {
+				self.strategy.update_common_number_for_peers(number);
+			},
 			ToServiceCommand::EventStream(tx) => self.event_streams.push(tx),
 			ToServiceCommand::RequestJustification(hash, number) =>
 				self.strategy.request_justification(&hash, number),

--- a/substrate/client/network/sync/src/fast_sync_engine.rs
+++ b/substrate/client/network/sync/src/fast_sync_engine.rs
@@ -1,0 +1,386 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! `SyncingEngine` is the actor responsible for syncing Substrate chain
+//! to tip and keep the blockchain up to date with network updates.
+
+mod syncing_service;
+
+use crate::{
+	pending_responses::{PendingResponses, ResponseEvent},
+	schema::v1::{StateRequest, StateResponse},
+	service::{
+		self,
+	},
+	strategy::{
+		state::StateStrategy
+	},
+	types::{
+		BadPeer, ExtendedPeerInfo, OpaqueStateRequest, OpaqueStateResponse, PeerRequest,
+	},
+	fast_sync_engine::syncing_service::{SyncingService, ToServiceCommand},
+	LOG_TARGET,
+};
+
+use futures::{
+	channel::oneshot,
+	FutureExt, StreamExt,
+};
+use libp2p::{request_response::OutboundFailure, PeerId};
+use log::{debug, error, info, trace};
+use prost::Message;
+
+use sc_client_api::{BlockBackend, ProofProvider};
+use sc_network::{
+	request_responses::{IfDisconnected, RequestFailure},
+	types::ProtocolName,
+	utils::LruHashSet,
+};
+use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver};
+use sp_blockchain::{Error as ClientError};
+use sp_runtime::{Justifications, traits::{Block as BlockT,}};
+use std::{
+	collections::{HashMap},
+	sync::{
+		Arc,
+	},
+	time::{ Instant },
+};
+use tokio::sync::Mutex;
+use sc_consensus::import_queue::ImportQueueService;
+use sc_consensus::IncomingBlock;
+use sp_runtime::traits::{NumberFor, Zero};
+use crate::state_request_handler::generate_protocol_name;
+use crate::strategy::state::StateStrategyAction;
+
+/// Peer information
+#[derive(Clone, Debug)]
+pub struct Peer<B: BlockT> {
+	pub info: ExtendedPeerInfo<B>,
+	/// Holds a set of blocks known to this peer.
+	pub known_blocks: LruHashSet<B::Hash>,
+}
+
+mod rep {
+	use sc_network::ReputationChange as Rep;
+	/// We received a message that failed to decode.
+	pub const BAD_MESSAGE: Rep = Rep::new(-(1 << 12), "Bad message");
+	/// Peer is on unsupported protocol version.
+	pub const BAD_PROTOCOL: Rep = Rep::new_fatal("Unsupported protocol");
+	/// Reputation change when a peer refuses a request.
+	pub const REFUSED: Rep = Rep::new(-(1 << 10), "Request refused");
+	/// Reputation change when a peer doesn't respond in time to our messages.
+	pub const TIMEOUT: Rep = Rep::new(-(1 << 10), "Request timeout");
+}
+
+pub struct FastSyncingEngine<B: BlockT, IQS> where
+	IQS: ImportQueueService<B> + ?Sized,
+{
+	/// Syncing strategy.
+	strategy: StateStrategy<B>,
+
+	/// Network service.
+	network_service: service::network::NetworkServiceHandle,
+
+	/// Channel for receiving service commands
+	service_rx: TracingUnboundedReceiver<ToServiceCommand<B>>,
+
+	/// All connected peers. Contains both full and light node peers.
+	peers: HashMap<PeerId, Peer<B>>,
+
+	/// When the syncing was started.
+	///
+	/// Stored as an `Option<Instant>` so once the initial wait has passed, `SyncingEngine`
+	/// can reset the peer timers and continue with the normal eviction process.
+	syncing_started: Option<Instant>,
+
+	/// Pending responses
+	pending_responses: PendingResponses<B>,
+
+	/// Protocol name used to send out state requests
+	state_request_protocol_name: ProtocolName,
+
+	/// Handle to import queue.
+	import_queue: Arc<Mutex<Box<IQS>>>,
+
+	last_block: Option<IncomingBlock<B>>,
+}
+
+impl<B: BlockT, IQS> FastSyncingEngine<B, IQS>
+where
+	B: BlockT,
+	IQS: ImportQueueService<B> + ?Sized + 'static,
+{
+	pub fn new<Client: BlockBackend<B>
+	+ ProofProvider<B>
+	+ Send
+	+ Sync
+	+ 'static>(
+		client: Arc<Client>,
+		import_queue:Arc<Mutex<Box<IQS>>>,
+		network_service: service::network::NetworkServiceHandle,
+		fork_id: Option<&str>,
+		target_header: B::Header,
+		target_body: Option<Vec<B::Extrinsic>>,
+		target_justifications: Option<Justifications>,
+		skip_proof: bool,
+		current_sync_peer: (PeerId, NumberFor<B>),
+	) -> Result<(Self, SyncingService<B>,), ClientError> {
+		let genesis_hash = client
+			.block_hash(Zero::zero())
+			.ok()
+			.flatten()
+			.expect("Genesis block exists; qed");
+		let state_request_protocol_name = generate_protocol_name(genesis_hash, fork_id).into();
+
+		// Initialize syncing strategy.
+		let strategy =
+			StateStrategy::new(client.clone(), target_header, target_body, target_justifications, skip_proof, vec![current_sync_peer].into_iter());
+
+		let (tx, service_rx) = tracing_unbounded("mpsc_chain_sync", 100_000);
+
+		Ok((
+			Self {
+				import_queue,
+				strategy,
+				network_service,
+				peers: HashMap::new(),
+				service_rx,
+				syncing_started: None,
+				pending_responses: PendingResponses::new(),
+				state_request_protocol_name,
+				last_block: None,
+			},
+			SyncingService::new(tx),
+		))
+	}
+
+	pub async fn run(mut self) -> Result<Option<IncomingBlock<B>>, ClientError> {
+		self.syncing_started = Some(Instant::now());
+
+		loop {
+			tokio::select! {
+				command = self.service_rx.select_next_some() =>
+					self.process_service_command(command),
+				response_event = self.pending_responses.select_next_some() =>
+					self.process_response_event(response_event),
+			}
+
+			// Process actions requested by a syncing strategy.
+			match self.process_strategy_actions().await {
+				Ok(Some(_)) => {
+					continue;
+				}
+				Ok(None) => {
+					info!("State import finished.");
+					break;
+				}
+				Err(e) => {
+					error!("Terminating `FastSyncingEngine` due to fatal error: {e:?}");
+					return Err(e)
+				}
+			}
+		}
+
+		return Ok(self.last_block.take());
+	}
+
+	async fn process_strategy_actions(&mut self) -> Result<Option<()>, ClientError> {
+		let actions = self.strategy.actions().collect::<Vec<_>>();
+		if actions.is_empty(){
+			return Err(ClientError::Backend("Fast sync failed - no further actions.".into()))
+		}
+
+		for action in actions.into_iter() {
+			match action {
+				StateStrategyAction::SendStateRequest { peer_id, request } => {
+					println!("Sending state request: {peer_id}");
+					self.send_state_request(peer_id, request);
+				}
+				StateStrategyAction::DropPeer(BadPeer(peer_id, rep)) => {
+					self.pending_responses.remove(&peer_id);
+					self.network_service
+						.disconnect_peer(peer_id, self.state_request_protocol_name.clone());
+					self.network_service.report_peer(peer_id, rep);
+
+					trace!(target: LOG_TARGET, "{peer_id:?} dropped: {rep:?}.");
+				}
+				StateStrategyAction::ImportBlocks { origin, blocks } => {
+					self.last_block = blocks.first().cloned();
+					let block_len = blocks.len();
+					self.import_queue.lock().await.import_blocks(origin, blocks);
+
+					info!("Import blocks finished, blocks len = {block_len}", );
+					return Ok(None)
+				}
+				StateStrategyAction::Finished => {
+					println!("StateStrategyAction::Finished");
+				}
+			}
+		}
+
+		Ok(Some(()))
+	}
+
+	fn process_service_command(&mut self, command: ToServiceCommand<B>) {
+		match command {
+			ToServiceCommand::Status(tx) => {
+				let mut status = self.strategy.status();
+				status.num_connected_peers = self.peers.len() as u32;
+				let _ = tx.send(status);
+			},
+			ToServiceCommand::PeersInfo(tx) => {
+				let peers_info = self
+					.peers
+					.iter()
+					.map(|(peer_id, peer)| (*peer_id, peer.info.clone()))
+					.collect();
+				let _ = tx.send(peers_info);
+			},
+			ToServiceCommand::Start(tx) => {
+				let _ = tx.send(());
+			}
+		}
+	}
+
+	fn send_state_request(&mut self, peer_id: PeerId, request: OpaqueStateRequest) {
+		let (tx, rx) = oneshot::channel();
+
+		self.pending_responses.insert(peer_id, PeerRequest::State, rx.boxed());
+
+		match Self::encode_state_request(&request) {
+			Ok(data) => {
+				println!("Preparing state request: {}, peer_id={peer_id}", data.len());
+				self.network_service.start_request(
+					peer_id,
+					self.state_request_protocol_name.clone(),
+					data,
+					tx,
+					IfDisconnected::ImmediateError,
+				);
+			},
+			Err(err) => {
+				log::warn!(
+					target: LOG_TARGET,
+					"Failed to encode state request {request:?}: {err:?}",
+				);
+			},
+		}
+	}
+
+	fn encode_state_request(request: &OpaqueStateRequest) -> Result<Vec<u8>, String> {
+		let request: &StateRequest = request.0.downcast_ref().ok_or_else(|| {
+			"Failed to downcast opaque state response during encoding, this is an \
+				implementation bug."
+				.to_string()
+		})?;
+
+		Ok(request.encode_to_vec())
+	}
+
+	fn decode_state_response(response: &[u8]) -> Result<OpaqueStateResponse, String> {
+		println!("decode_state_response: {}", response.len());
+		let response = StateResponse::decode(response)
+			.map_err(|error| format!("Failed to decode state response: {error}"))?;
+
+		Ok(OpaqueStateResponse(Box::new(response)))
+	}
+
+	fn process_response_event(&mut self, response_event: ResponseEvent<B>) {
+		let ResponseEvent { peer_id, request, response } = response_event;
+		println!("Process response event: {peer_id}");
+
+		match response {
+			Ok(Ok((resp, _))) => match request {
+				PeerRequest::Block(req) => {
+					error!("Unexpected PeerRequest::Block - {:?}", req);
+				},
+				PeerRequest::State => {
+					let response = match Self::decode_state_response(&resp[..]) {
+						Ok(proto) => proto,
+						Err(e) => {
+							debug!(
+								target: LOG_TARGET,
+								"Failed to decode state response from peer {peer_id:?}: {e:?}.",
+							);
+							self.network_service.report_peer(peer_id, rep::BAD_MESSAGE);
+							self.network_service.disconnect_peer(
+								peer_id,
+								self.state_request_protocol_name.clone(),
+							);
+							return
+						},
+					};
+
+					self.strategy.on_state_response(peer_id, response);
+				},
+				PeerRequest::WarpProof => {
+					error!("Unexpected PeerRequest::WarpProof",);
+				},
+			},
+			Ok(Err(e)) => {
+				debug!(target: LOG_TARGET, "Request to peer {peer_id:?} failed: {e:?}.");
+
+				match e {
+					RequestFailure::Network(OutboundFailure::Timeout) => {
+						self.network_service.report_peer(peer_id, rep::TIMEOUT);
+						self.network_service
+							.disconnect_peer(peer_id, self.state_request_protocol_name.clone());
+					},
+					RequestFailure::Network(OutboundFailure::UnsupportedProtocols) => {
+						self.network_service.report_peer(peer_id, rep::BAD_PROTOCOL);
+						self.network_service
+							.disconnect_peer(peer_id, self.state_request_protocol_name.clone());
+					},
+					RequestFailure::Network(OutboundFailure::DialFailure) => {
+						self.network_service
+							.disconnect_peer(peer_id, self.state_request_protocol_name.clone());
+					},
+					RequestFailure::Refused => {
+						self.network_service.report_peer(peer_id, rep::REFUSED);
+						self.network_service
+							.disconnect_peer(peer_id, self.state_request_protocol_name.clone());
+					},
+					RequestFailure::Network(OutboundFailure::ConnectionClosed) |
+					RequestFailure::NotConnected => {
+						self.network_service
+							.disconnect_peer(peer_id, self.state_request_protocol_name.clone());
+					},
+					RequestFailure::UnknownProtocol => {
+						debug_assert!(false, "Block request protocol should always be known.");
+					},
+					RequestFailure::Obsolete => {
+						debug_assert!(
+							false,
+							"Can not receive `RequestFailure::Obsolete` after dropping the \
+								response receiver.",
+						);
+					},
+				}
+			},
+			Err(oneshot::Canceled) => {
+				trace!(
+					target: LOG_TARGET,
+					"Request to peer {peer_id:?} failed due to oneshot being canceled.",
+				);
+				self.network_service
+					.disconnect_peer(peer_id, self.state_request_protocol_name.clone());
+			},
+		}
+	}
+}

--- a/substrate/client/network/sync/src/fast_sync_engine/syncing_service.rs
+++ b/substrate/client/network/sync/src/fast_sync_engine/syncing_service.rs
@@ -1,0 +1,73 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::types::{ExtendedPeerInfo, SyncStatus, };
+
+use futures::{channel::oneshot,};
+use libp2p::PeerId;
+use sc_utils::mpsc::TracingUnboundedSender;
+use sp_runtime::traits::{Block as BlockT};
+
+/// Commands send to `SyncingEngine`
+pub enum ToServiceCommand<B: BlockT> {
+	Start(oneshot::Sender<()>),
+	Status(oneshot::Sender<SyncStatus<B>>),
+	PeersInfo(oneshot::Sender<Vec<(PeerId, ExtendedPeerInfo<B>)>>),
+}
+
+/// Handle for communicating with `SyncingEngine` asynchronously
+#[derive(Clone)]
+pub struct SyncingService<B: BlockT> {
+	tx: TracingUnboundedSender<ToServiceCommand<B>>,
+}
+
+impl<B: BlockT> SyncingService<B> {
+	/// Create new handle
+	pub fn new(
+		tx: TracingUnboundedSender<ToServiceCommand<B>>,
+	) -> Self {
+		Self { tx, }
+	}
+
+	/// Get peer information.
+	pub async fn peers_info(
+		&self,
+	) -> Result<Vec<(PeerId, ExtendedPeerInfo<B>)>, oneshot::Canceled> {
+		let (tx, rx) = oneshot::channel();
+		let _ = self.tx.unbounded_send(ToServiceCommand::PeersInfo(tx));
+
+		rx.await
+	}
+
+	/// Get sync status
+	///
+	/// Returns an error if `SyncingEngine` has terminated.
+	pub async fn status(&self) -> Result<SyncStatus<B>, oneshot::Canceled> {
+		let (tx, rx) = oneshot::channel();
+		let _ = self.tx.unbounded_send(ToServiceCommand::Status(tx));
+
+		rx.await
+	}
+
+	pub async fn start(&self) -> Result<(), oneshot::Canceled> {
+		let (tx, rx) = oneshot::channel();
+		let _ = self.tx.unbounded_send(ToServiceCommand::Start(tx));
+
+		rx.await
+	}
+}

--- a/substrate/client/network/sync/src/lib.rs
+++ b/substrate/client/network/sync/src/lib.rs
@@ -39,6 +39,7 @@ pub mod service;
 pub mod state_request_handler;
 pub mod strategy;
 pub mod warp_request_handler;
+pub mod fast_sync_engine;
 
 /// Log target for this crate.
 const LOG_TARGET: &str = "sync";

--- a/substrate/client/network/sync/src/service/syncing_service.rs
+++ b/substrate/client/network/sync/src/service/syncing_service.rs
@@ -36,6 +36,7 @@ use std::{
 
 /// Commands send to `SyncingEngine`
 pub enum ToServiceCommand<B: BlockT> {
+	NewBestBlockNumber(NumberFor<B>),
 	SetSyncForkRequest(Vec<PeerId>, B::Hash, NumberFor<B>),
 	RequestJustification(B::Hash, NumberFor<B>),
 	ClearJustificationRequests,
@@ -89,6 +90,15 @@ impl<B: BlockT> SyncingService<B> {
 		let _ = self.tx.unbounded_send(ToServiceCommand::NumActivePeers(tx));
 
 		rx.await
+	}
+
+	pub fn new_best_number(
+		&self,
+		number: NumberFor<B>,
+	) {
+		let _ = self
+			.tx
+			.unbounded_send(ToServiceCommand::NewBestBlockNumber(number));
 	}
 
 	/// Get best seen block.

--- a/substrate/client/network/sync/src/state_request_handler.rs
+++ b/substrate/client/network/sync/src/state_request_handler.rs
@@ -53,7 +53,7 @@ mod rep {
 }
 
 /// Generates a [`ProtocolConfig`] for the state request protocol, refusing incoming requests.
-pub fn generate_protocol_config<Hash: AsRef<[u8]>>(
+fn generate_protocol_config<Hash: AsRef<[u8]>>(
 	protocol_id: &ProtocolId,
 	genesis_hash: Hash,
 	fork_id: Option<&str>,
@@ -70,7 +70,7 @@ pub fn generate_protocol_config<Hash: AsRef<[u8]>>(
 }
 
 /// Generate the state protocol name from the genesis hash and fork id.
-fn generate_protocol_name<Hash: AsRef<[u8]>>(genesis_hash: Hash, fork_id: Option<&str>) -> String {
+pub fn generate_protocol_name<Hash: AsRef<[u8]>>(genesis_hash: Hash, fork_id: Option<&str>) -> String {
 	let genesis_hash = genesis_hash.as_ref();
 	if let Some(fork_id) = fork_id {
 		format!("/{}/{}/state/2", array_bytes::bytes2hex("", genesis_hash), fork_id)

--- a/substrate/client/network/sync/src/strategy.rs
+++ b/substrate/client/network/sync/src/strategy.rs
@@ -20,7 +20,7 @@
 //! and specific syncing algorithms.
 
 pub mod chain_sync;
-mod state;
+pub mod state;
 pub mod state_sync;
 pub mod warp;
 
@@ -197,6 +197,18 @@ where
 			SyncingStrategy::StateSyncStrategy(_) => {},
 			SyncingStrategy::ChainSyncStrategy(strategy) =>
 				strategy.set_sync_fork_request(peers, hash, number),
+		}
+	}
+
+	pub fn update_common_number_for_peers(
+		&mut self,
+		number: NumberFor<B>,
+	) {
+		match self {
+			SyncingStrategy::WarpSyncStrategy(_) => {},
+			SyncingStrategy::StateSyncStrategy(_) => {},
+			SyncingStrategy::ChainSyncStrategy(strategy) =>
+				strategy.update_common_number_for_peers(number),
 		}
 	}
 

--- a/substrate/client/network/sync/src/strategy/chain_sync.rs
+++ b/substrate/client/network/sync/src/strategy/chain_sync.rs
@@ -1287,6 +1287,16 @@ where
 		}
 	}
 
+	pub fn update_common_number_for_peers(&mut self, new_common: NumberFor<B>) {
+		for peer in self.peers.values_mut() {
+			if peer.best_number >= new_common {
+				peer.update_common_number(new_common);
+			} else {
+				peer.update_common_number(peer.best_number);
+			}
+		}
+	}
+
 	/// Called when a block has been queued for import.
 	///
 	/// Updates our internal state for best queued block and then goes

--- a/substrate/client/network/sync/src/strategy/chain_sync.rs
+++ b/substrate/client/network/sync/src/strategy/chain_sync.rs
@@ -76,7 +76,7 @@ mod test;
 const MAX_IMPORTING_BLOCKS: usize = 2048;
 
 /// Maximum blocks to download ahead of any gap.
-const MAX_DOWNLOAD_AHEAD: u32 = 2048;
+const MAX_DOWNLOAD_AHEAD: u32 = 20480;
 
 /// Maximum blocks to look backwards. The gap is the difference between the highest block and the
 /// common block of a node.

--- a/substrate/client/network/sync/src/strategy/chain_sync.rs
+++ b/substrate/client/network/sync/src/strategy/chain_sync.rs
@@ -703,6 +703,7 @@ where
 		request: Option<BlockRequest<B>>,
 		response: BlockResponse<B>,
 	) -> Result<(), BadPeer> {
+		println!("Block response (len) peer_id={peer_id}: {}", response.blocks.len());
 		self.downloaded_blocks += response.blocks.len();
 		let mut gap = false;
 		let new_blocks: Vec<IncomingBlock<B>> = if let Some(peer) = self.peers.get_mut(peer_id) {
@@ -714,7 +715,8 @@ where
 			self.allowed_requests.add(peer_id);
 			if let Some(request) = request {
 				match &mut peer.state {
-					PeerSyncState::DownloadingNew(_) => {
+					PeerSyncState::DownloadingNew(num) => {
+						println!("PeerSyncState::DownloadingNew peer_id={peer_id}: {}", num);
 						self.blocks.clear_peer_download(peer_id);
 						peer.state = PeerSyncState::Available;
 						if let Some(start_block) =
@@ -724,7 +726,8 @@ where
 						}
 						self.ready_blocks()
 					},
-					PeerSyncState::DownloadingGap(_) => {
+					PeerSyncState::DownloadingGap(num) => {
+						println!("PeerSyncState::DownloadingGap peer_id={peer_id}: {}", num);
 						peer.state = PeerSyncState::Available;
 						if let Some(gap_sync) = &mut self.gap_sync {
 							gap_sync.blocks.clear_peer_download(peer_id);
@@ -759,7 +762,7 @@ where
 									}
 								})
 								.collect();
-							debug!(
+							info!(
 								target: LOG_TARGET,
 								"Drained {} gap blocks from {}",
 								blocks.len(),
@@ -767,11 +770,12 @@ where
 							);
 							blocks
 						} else {
-							debug!(target: LOG_TARGET, "Unexpected gap block response from {peer_id}");
+							info!(target: LOG_TARGET, "Unexpected gap block response from {peer_id}");
 							return Err(BadPeer(*peer_id, rep::NO_BLOCK))
 						}
 					},
-					PeerSyncState::DownloadingStale(_) => {
+					PeerSyncState::DownloadingStale(num) => {
+						println!("PeerSyncState::DownloadingStale peer_id={peer_id}: {}", num);
 						peer.state = PeerSyncState::Available;
 						if blocks.is_empty() {
 							debug!(target: LOG_TARGET, "Empty block response from {peer_id}");
@@ -800,6 +804,7 @@ where
 							.collect()
 					},
 					PeerSyncState::AncestorSearch { current, start, state } => {
+						println!("PeerSyncState::AncestorSearch peer_id={peer_id}: {}, {}", current, start);
 						let matching_hash = match (blocks.get(0), self.client.hash(*current)) {
 							(Some(block), Ok(maybe_our_block_hash)) => {
 								trace!(
@@ -1034,7 +1039,7 @@ where
 				let median = heads[heads.len() / 2];
 				if number + STATE_SYNC_FINALITY_THRESHOLD.saturated_into() >= median {
 					if let Ok(Some(header)) = self.client.header(*hash) {
-						log::debug!(
+						log::info!(
 							target: LOG_TARGET,
 							"Starting state sync for #{number} ({hash})",
 						);
@@ -1345,7 +1350,7 @@ where
 			warn!(target: LOG_TARGET, "💔  Unable to restart sync: {e}");
 		}
 		self.allowed_requests.set_all();
-		debug!(
+		info!(
 			target: LOG_TARGET,
 			"Restarted with {} ({})",
 			self.best_queued_number,
@@ -1358,7 +1363,7 @@ where
 			// should be kept in that state.
 			if let PeerSyncState::DownloadingJustification(_) = p.state {
 				// We make sure our commmon number is at least something we have.
-				trace!(
+				info!(
 					target: LOG_TARGET,
 					"Keeping peer {} after restart, updating common number from={} => to={} (our best).",
 					peer_id,
@@ -1407,25 +1412,25 @@ where
 			self.import_existing = true;
 			// Latest state is missing, start with the last finalized state or genesis instead.
 			if let Some((hash, number)) = info.finalized_state {
-				debug!(target: LOG_TARGET, "Starting from finalized state #{number}");
+				info!(target: LOG_TARGET, "Starting from finalized state #{number}");
 				self.best_queued_hash = hash;
 				self.best_queued_number = number;
 			} else {
-				debug!(target: LOG_TARGET, "Restarting from genesis");
+				info!(target: LOG_TARGET, "Restarting from genesis");
 				self.best_queued_hash = Default::default();
 				self.best_queued_number = Zero::zero();
 			}
 		}
 
 		if let Some((start, end)) = info.block_gap {
-			debug!(target: LOG_TARGET, "Starting gap sync #{start} - #{end}");
+			info!(target: LOG_TARGET, "Starting gap sync #{start} - #{end}");
 			self.gap_sync = Some(GapSync {
 				best_queued_number: start - One::one(),
 				target: end,
 				blocks: BlockCollection::new(),
 			});
 		}
-		trace!(
+		info!(
 			target: LOG_TARGET,
 			"Restarted sync at #{} ({:?})",
 			self.best_queued_number,
@@ -1780,7 +1785,7 @@ where
 		count: usize,
 		results: Vec<(Result<BlockImportStatus<NumberFor<B>>, BlockImportError>, B::Hash)>,
 	) {
-		trace!(target: LOG_TARGET, "Imported {imported} of {count}");
+		info!(target: LOG_TARGET, "Imported {imported} of {count}");
 
 		let mut has_error = false;
 		for (_, hash) in &results {
@@ -1798,13 +1803,15 @@ where
 			has_error |= result.is_err();
 
 			match result {
-				Ok(BlockImportStatus::ImportedKnown(number, peer_id)) =>
+				Ok(BlockImportStatus::ImportedKnown(number, peer_id)) => {
+					info!("ImportedKnown:{number}");
 					if let Some(peer) = peer_id {
 						self.update_peer_common_number(&peer, number);
-					},
+					}
+				},
 				Ok(BlockImportStatus::ImportedUnknown(number, aux, peer_id)) => {
 					if aux.clear_justification_requests {
-						trace!(
+						info!(
 							target: LOG_TARGET,
 							"Block imported clears all pending justification requests {number}: {hash:?}",
 						);
@@ -1812,7 +1819,7 @@ where
 					}
 
 					if aux.needs_justification {
-						trace!(
+						info!(
 							target: LOG_TARGET,
 							"Block imported but requires justification {number}: {hash:?}",
 						);

--- a/substrate/client/network/sync/src/strategy/state.rs
+++ b/substrate/client/network/sync/src/strategy/state.rs
@@ -25,7 +25,7 @@ use crate::{
 	LOG_TARGET,
 };
 use libp2p::PeerId;
-use log::{debug, error, trace};
+use log::{debug, error, info, trace};
 use sc_client_api::ProofProvider;
 use sc_consensus::{BlockImportError, BlockImportStatus, IncomingBlock};
 use sc_network_common::sync::message::BlockAnnounce;
@@ -58,6 +58,7 @@ pub enum StateStrategyAction<B: BlockT> {
 	Finished,
 }
 
+#[derive(Debug)]
 enum PeerState {
 	Available,
 	DownloadingState,
@@ -69,6 +70,7 @@ impl PeerState {
 	}
 }
 
+#[derive(Debug)]
 struct Peer<B: BlockT> {
 	best_number: NumberFor<B>,
 	state: PeerState,
@@ -215,6 +217,7 @@ impl<B: BlockT> StateStrategy<B> {
 					state: Some(state),
 				};
 				debug!(target: LOG_TARGET, "State download is complete. Import is queued");
+				info!(target: LOG_TARGET, "State download is complete. Import is queued"); // TODO
 				self.actions
 					.push(StateStrategyAction::ImportBlocks { origin, blocks: vec![block] });
 				Ok(())
@@ -344,6 +347,8 @@ impl<B: BlockT> StateStrategy<B> {
 			.into_iter()
 			.map(|(peer_id, request)| StateStrategyAction::SendStateRequest { peer_id, request });
 		self.actions.extend(state_request);
+
+		println!("Actions: {}", self.actions.len());
 
 		std::mem::take(&mut self.actions).into_iter()
 	}

--- a/substrate/client/service/src/lib.rs
+++ b/substrate/client/service/src/lib.rs
@@ -48,7 +48,7 @@ use sc_network_sync::SyncingService;
 use sc_utils::mpsc::TracingUnboundedReceiver;
 use sp_blockchain::HeaderMetadata;
 use sp_consensus::SyncOracle;
-use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
 
 pub use self::{
 	builder::{
@@ -88,6 +88,7 @@ pub use sc_transaction_pool::Options as TransactionPoolOptions;
 pub use sc_transaction_pool_api::{error::IntoPoolError, InPoolTransaction, TransactionPool};
 #[doc(hidden)]
 pub use std::{ops::Deref, result::Result, sync::Arc};
+use sp_runtime::Justifications;
 pub use task_manager::{SpawnTaskHandle, Task, TaskManager, TaskRegistry, DEFAULT_GROUP_NAME};
 
 const DEFAULT_PROTOCOL_ID: &str = "sup";
@@ -95,6 +96,29 @@ const DEFAULT_PROTOCOL_ID: &str = "sup";
 /// RPC handlers that can perform RPC queries.
 #[derive(Clone)]
 pub struct RpcHandlers(Arc<RpcModule<()>>);
+
+#[derive(Clone, Debug)]
+/// Data container to insert the block into the BlockchainDb without checks.
+pub struct RawBlockData<Block: BlockT>{
+	/// Block hash
+	pub hash: Block::Hash,
+	/// Block header
+	pub header: Block::Header,
+	/// Extrinsics of the block
+	pub block_body: Option<Vec<Block::Extrinsic>>,
+	/// Justifications of the block
+	pub justifications: Option<Justifications>
+}
+
+/// Provides extended functions for `Client` to enable fast-sync.
+pub trait ClientExt<Block: BlockT>{
+	/// Insert block into BlockchainDb bypassing checks.
+	fn import_raw_block(&self, raw_block: RawBlockData<Block>) -> Result<(), sp_blockchain::Error>;
+	/// Clear block gap after initial block insertion.
+	fn clear_block_gap(&self);
+	/// Update block gap to specific value.
+	fn update_block_gap(&self, start: NumberFor<Block>, end: NumberFor<Block>);
+}
 
 impl RpcHandlers {
 	/// Starts an RPC query.

--- a/substrate/client/state-db/src/lib.rs
+++ b/substrate/client/state-db/src/lib.rs
@@ -462,15 +462,17 @@ impl<BlockHash: Hash, Key: Hash, D: MetaDb> StateDbSync<BlockHash, Key, D> {
 		match self.mode {
 			PruningMode::ArchiveAll => Ok(()),
 			PruningMode::ArchiveCanonical | PruningMode::Constrained(_) => {
+				let hint_value = hint();
 				let have_block = self.non_canonical.have_block(hash) ||
 					self.pruning.as_ref().map_or_else(
-						|| hint(),
+						|| hint_value,
 						|pruning| match pruning.have_block(hash, number) {
 							HaveBlock::No => false,
 							HaveBlock::Yes => true,
 							HaveBlock::Maybe => hint(),
 						},
 					);
+			//	println!("have_block = {have_block} #{number} {hash:?}");
 				if have_block {
 					let refs = self.pinned.entry(hash.clone()).or_default();
 					if *refs == 0 {

--- a/substrate/primitives/blockchain/src/backend.rs
+++ b/substrate/primitives/blockchain/src/backend.rs
@@ -255,6 +255,10 @@ pub trait Backend<Block: BlockT>:
 	}
 
 	fn block_indexed_body(&self, hash: Block::Hash) -> Result<Option<Vec<Vec<u8>>>>;
+
+	fn clear_block_gap(&self);
+
+	fn update_block_gap(&self, start: NumberFor<Block>, end: NumberFor<Block>);
 }
 
 /// Blockchain info

--- a/substrate/primitives/consensus/common/src/lib.rs
+++ b/substrate/primitives/consensus/common/src/lib.rs
@@ -69,6 +69,8 @@ pub enum BlockOrigin {
 	Own,
 	/// Block was imported from a file.
 	File,
+	/// Block was imported using fast sync.
+	FastSync,
 }
 
 /// Environment for a Consensus instance.


### PR DESCRIPTION
This PR adds support for the upcoming fast-sync algorithm from subspace-node (WIP).

Changes:
- add a method for "raw-import" block which bypasses the majority of checks and execution
- add `fast-sync-engine` - a simplified version of the `sync-engine` which enables access to existing `state-sync` strategy
- add operations for removing the block gap metadata that Substrate calculates when we insert not the sequential block 
- change Substrate constants to support our scenario
- expose currently connected peers (open peers)
- add `NewBestBlockNumber` event to update common block number with connected peers.

Changed constants like BLOCKS_AHEAD must be set to correct values (WIP). 

The 'Logs' commit contains only temporary logs and must be removed before the merge. 