### PR TITLE
Support fast-sync algorithm

### DIFF
--- a/substrate/client/api/src/in_mem.rs
+++ b/substrate/client/api/src/in_mem.rs
@@ -447,6 +447,14 @@ impl<Block: BlockT> blockchain::Backend<Block> for Blockchain<Block> {
 	) -> sp_blockchain::Result<Option<Vec<Vec<u8>>>> {
 		unimplemented!("Not supported by the in-mem backend.")
 	}
+
+	fn clear_block_gap(&self) {
+		unimplemented!("Not supported by the in-mem backend.")
+	}
+
+	fn update_block_gap(&self, _: NumberFor<Block>, _: NumberFor<Block>) {
+		unimplemented!("Not supported by the in-mem backend.")
+	}
 }
 
 impl<Block: BlockT> backend::AuxStore for Blockchain<Block> {

--- a/substrate/client/db/src/lib.rs
+++ b/substrate/client/db/src/lib.rs
@@ -790,6 +790,16 @@ impl<Block: BlockT> sc_client_api::blockchain::Backend<Block> for BlockchainDb<B
 				Err(sp_blockchain::Error::Backend(format!("Error decoding body list: {}", err))),
 		}
 	}
+
+	fn clear_block_gap(&self) {
+		debug!(target: "sync", "Clear block gap.");
+		self.update_block_gap(None);
+	}
+
+	fn update_block_gap(&self, start: NumberFor<Block>, end: NumberFor<Block>) {
+		debug!(target: "sync", "Update block gap: {}-{}", start, end);
+		self.update_block_gap(Some((start, end)));
+	}
 }
 
 impl<Block: BlockT> HeaderMetadata<Block> for BlockchainDb<Block> {
@@ -1761,6 +1771,7 @@ impl<Block: BlockT> Backend<Block> {
 		for m in meta_updates {
 			self.blockchain.update_meta(m);
 		}
+
 		self.blockchain.update_block_gap(block_gap);
 
 		Ok(())

--- a/substrate/client/network/src/service.rs
+++ b/substrate/client/network/src/service.rs
@@ -743,6 +743,21 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 		rx.await.map_err(|_| ())
 	}
 
+	/// Returns a collection of currently connected (open) peers.
+	pub async fn open_peers(&self) -> Result<Vec<PeerId>, ()> {
+		let (tx, rx) = oneshot::channel();
+
+		let _ = self
+			.to_worker
+			.unbounded_send(ServiceToWorkerMsg::OpenPeers { pending_response: tx });
+
+		match rx.await {
+			Ok(v) => Ok(v),
+			// The channel can only be closed if the network worker no longer exists.
+			Err(_) => Err(()),
+		}
+	}
+
 	/// Utility function to extract `PeerId` from each `Multiaddr` for peer set updates.
 	///
 	/// Returns an `Err` if one of the given addresses is invalid or contains an
@@ -1173,6 +1188,9 @@ enum ServiceToWorkerMsg {
 	NetworkState {
 		pending_response: oneshot::Sender<Result<NetworkState, RequestFailure>>,
 	},
+	OpenPeers {
+		pending_response: oneshot::Sender<Vec<PeerId>>,
+	},
 	DisconnectPeer(PeerId, ProtocolName),
 }
 
@@ -1315,7 +1333,19 @@ where
 				.behaviour_mut()
 				.user_protocol_mut()
 				.disconnect_peer(&who, protocol_name),
+			ServiceToWorkerMsg::OpenPeers { pending_response } => {
+				let _ = pending_response.send(self.open_peers());
+			},
 		}
+	}
+
+	fn open_peers(&self) -> Vec<PeerId> {
+		self.network_service
+			.behaviour()
+			.user_protocol()
+			.open_peers()
+			.cloned()
+			.collect::<Vec<_>>()
 	}
 
 	/// Process the next event coming from `Swarm`.

--- a/substrate/client/network/sync/src/engine.rs
+++ b/substrate/client/network/sync/src/engine.rs
@@ -839,6 +839,9 @@ where
 			ToServiceCommand::SetSyncForkRequest(peers, hash, number) => {
 				self.strategy.set_sync_fork_request(peers, &hash, number);
 			},
+			ToServiceCommand::NewBestBlockNumber(number) => {
+				self.strategy.update_common_number_for_peers(number);
+			},
 			ToServiceCommand::EventStream(tx) => self.event_streams.push(tx),
 			ToServiceCommand::RequestJustification(hash, number) =>
 				self.strategy.request_justification(&hash, number),

--- a/substrate/client/network/sync/src/fast_sync_engine.rs
+++ b/substrate/client/network/sync/src/fast_sync_engine.rs
@@ -1,0 +1,366 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! `SyncingEngine` is the actor responsible for syncing Substrate chain
+//! to tip and keep the blockchain up to date with network updates.
+
+mod syncing_service;
+
+use crate::{
+	fast_sync_engine::syncing_service::{SyncingService, ToServiceCommand},
+	pending_responses::{PendingResponses, ResponseEvent},
+	schema::v1::{StateRequest, StateResponse},
+	service::{self},
+	strategy::state::StateStrategy,
+	types::{BadPeer, ExtendedPeerInfo, OpaqueStateRequest, OpaqueStateResponse, PeerRequest},
+	LOG_TARGET,
+};
+
+use futures::{channel::oneshot, FutureExt, StreamExt};
+use libp2p::{request_response::OutboundFailure, PeerId};
+use log::{debug, error, trace};
+use prost::Message;
+
+use crate::{state_request_handler::generate_protocol_name, strategy::state::StateStrategyAction};
+use sc_client_api::{BlockBackend, ProofProvider};
+use sc_consensus::{import_queue::ImportQueueService, IncomingBlock};
+use sc_network::{
+	request_responses::{IfDisconnected, RequestFailure},
+	types::ProtocolName,
+	utils::LruHashSet,
+};
+use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver};
+use sp_blockchain::Error as ClientError;
+use sp_runtime::{
+	traits::{Block as BlockT, NumberFor, Zero},
+	Justifications,
+};
+use std::{collections::HashMap, sync::Arc, time::Instant};
+use tokio::sync::Mutex;
+
+/// Peer information
+#[derive(Clone, Debug)]
+pub struct Peer<B: BlockT> {
+	pub info: ExtendedPeerInfo<B>,
+	/// Holds a set of blocks known to this peer.
+	pub known_blocks: LruHashSet<B::Hash>,
+}
+
+mod rep {
+	use sc_network::ReputationChange as Rep;
+	/// We received a message that failed to decode.
+	pub const BAD_MESSAGE: Rep = Rep::new(-(1 << 12), "Bad message");
+	/// Peer is on unsupported protocol version.
+	pub const BAD_PROTOCOL: Rep = Rep::new_fatal("Unsupported protocol");
+	/// Reputation change when a peer refuses a request.
+	pub const REFUSED: Rep = Rep::new(-(1 << 10), "Request refused");
+	/// Reputation change when a peer doesn't respond in time to our messages.
+	pub const TIMEOUT: Rep = Rep::new(-(1 << 10), "Request timeout");
+}
+
+pub struct FastSyncingEngine<B: BlockT, IQS>
+where
+	IQS: ImportQueueService<B> + ?Sized,
+{
+	/// Syncing strategy.
+	strategy: StateStrategy<B>,
+
+	/// Network service.
+	network_service: service::network::NetworkServiceHandle,
+
+	/// Channel for receiving service commands
+	service_rx: TracingUnboundedReceiver<ToServiceCommand<B>>,
+
+	/// All connected peers. Contains both full and light node peers.
+	peers: HashMap<PeerId, Peer<B>>,
+
+	/// When the syncing was started.
+	///
+	/// Stored as an `Option<Instant>` so once the initial wait has passed, `SyncingEngine`
+	/// can reset the peer timers and continue with the normal eviction process.
+	syncing_started: Option<Instant>,
+
+	/// Pending responses
+	pending_responses: PendingResponses<B>,
+
+	/// Protocol name used to send out state requests
+	state_request_protocol_name: ProtocolName,
+
+	/// Handle to import queue.
+	import_queue: Arc<Mutex<Box<IQS>>>,
+
+	last_block: Option<IncomingBlock<B>>,
+}
+
+impl<B: BlockT, IQS> FastSyncingEngine<B, IQS>
+where
+	B: BlockT,
+	IQS: ImportQueueService<B> + ?Sized + 'static,
+{
+	pub fn new<Client: BlockBackend<B> + ProofProvider<B> + Send + Sync + 'static>(
+		client: Arc<Client>,
+		import_queue: Arc<Mutex<Box<IQS>>>,
+		network_service: service::network::NetworkServiceHandle,
+		fork_id: Option<&str>,
+		target_header: B::Header,
+		target_body: Option<Vec<B::Extrinsic>>,
+		target_justifications: Option<Justifications>,
+		skip_proof: bool,
+		current_sync_peer: (PeerId, NumberFor<B>),
+	) -> Result<(Self, SyncingService<B>), ClientError> {
+		let genesis_hash = client
+			.block_hash(Zero::zero())
+			.ok()
+			.flatten()
+			.expect("Genesis block exists; qed");
+		let state_request_protocol_name = generate_protocol_name(genesis_hash, fork_id).into();
+
+		// Initialize syncing strategy.
+		let strategy = StateStrategy::new(
+			client.clone(),
+			target_header,
+			target_body,
+			target_justifications,
+			skip_proof,
+			vec![current_sync_peer].into_iter(),
+		);
+
+		let (tx, service_rx) = tracing_unbounded("mpsc_chain_sync", 100_000);
+
+		Ok((
+			Self {
+				import_queue,
+				strategy,
+				network_service,
+				peers: HashMap::new(),
+				service_rx,
+				syncing_started: None,
+				pending_responses: PendingResponses::new(),
+				state_request_protocol_name,
+				last_block: None,
+			},
+			SyncingService::new(tx),
+		))
+	}
+
+	pub async fn run(mut self) -> Result<Option<IncomingBlock<B>>, ClientError> {
+		self.syncing_started = Some(Instant::now());
+
+		loop {
+			tokio::select! {
+				command = self.service_rx.select_next_some() =>
+					self.process_service_command(command),
+				response_event = self.pending_responses.select_next_some() =>
+					self.process_response_event(response_event),
+			}
+
+			// Process actions requested by a syncing strategy.
+			match self.process_strategy_actions().await {
+				Ok(Some(_)) => {
+					continue;
+				},
+				Ok(None) => {
+					trace!("State import finished.");
+					break;
+				},
+				Err(e) => {
+					error!("Terminating `FastSyncingEngine` due to fatal error: {e:?}");
+					return Err(e)
+				},
+			}
+		}
+
+		return Ok(self.last_block.take());
+	}
+
+	async fn process_strategy_actions(&mut self) -> Result<Option<()>, ClientError> {
+		let actions = self.strategy.actions().collect::<Vec<_>>();
+		if actions.is_empty() {
+			return Err(ClientError::Backend("Fast sync failed - no further actions.".into()))
+		}
+
+		for action in actions.into_iter() {
+			match action {
+				StateStrategyAction::SendStateRequest { peer_id, request } => {
+					self.send_state_request(peer_id, request);
+				},
+				StateStrategyAction::DropPeer(BadPeer(peer_id, rep)) => {
+					self.pending_responses.remove(&peer_id);
+					self.network_service
+						.disconnect_peer(peer_id, self.state_request_protocol_name.clone());
+					self.network_service.report_peer(peer_id, rep);
+
+					trace!(target: LOG_TARGET, "{peer_id:?} dropped: {rep:?}.");
+				},
+				StateStrategyAction::ImportBlocks { origin, blocks } => {
+					self.last_block = blocks.first().cloned();
+					self.import_queue.lock().await.import_blocks(origin, blocks);
+
+					return Ok(None)
+				},
+				StateStrategyAction::Finished => {
+					trace!("State strategy action finished.");
+				},
+			}
+		}
+
+		Ok(Some(()))
+	}
+
+	fn process_service_command(&mut self, command: ToServiceCommand<B>) {
+		match command {
+			ToServiceCommand::Status(tx) => {
+				let mut status = self.strategy.status();
+				status.num_connected_peers = self.peers.len() as u32;
+				let _ = tx.send(status);
+			},
+			ToServiceCommand::PeersInfo(tx) => {
+				let peers_info = self
+					.peers
+					.iter()
+					.map(|(peer_id, peer)| (*peer_id, peer.info.clone()))
+					.collect();
+				let _ = tx.send(peers_info);
+			},
+			ToServiceCommand::Start(tx) => {
+				let _ = tx.send(());
+			},
+		}
+	}
+
+	fn send_state_request(&mut self, peer_id: PeerId, request: OpaqueStateRequest) {
+		let (tx, rx) = oneshot::channel();
+
+		self.pending_responses.insert(peer_id, PeerRequest::State, rx.boxed());
+
+		match Self::encode_state_request(&request) {
+			Ok(data) => {
+				self.network_service.start_request(
+					peer_id,
+					self.state_request_protocol_name.clone(),
+					data,
+					tx,
+					IfDisconnected::ImmediateError,
+				);
+			},
+			Err(err) => {
+				log::warn!(
+					target: LOG_TARGET,
+					"Failed to encode state request {request:?}: {err:?}",
+				);
+			},
+		}
+	}
+
+	fn encode_state_request(request: &OpaqueStateRequest) -> Result<Vec<u8>, String> {
+		let request: &StateRequest = request.0.downcast_ref().ok_or_else(|| {
+			"Failed to downcast opaque state response during encoding, this is an \
+				implementation bug."
+				.to_string()
+		})?;
+
+		Ok(request.encode_to_vec())
+	}
+
+	fn decode_state_response(response: &[u8]) -> Result<OpaqueStateResponse, String> {
+		let response = StateResponse::decode(response)
+			.map_err(|error| format!("Failed to decode state response: {error}"))?;
+
+		Ok(OpaqueStateResponse(Box::new(response)))
+	}
+
+	fn process_response_event(&mut self, response_event: ResponseEvent<B>) {
+		let ResponseEvent { peer_id, request, response } = response_event;
+
+		match response {
+			Ok(Ok((resp, _))) => match request {
+				PeerRequest::Block(req) => {
+					error!("Unexpected PeerRequest::Block - {:?}", req);
+				},
+				PeerRequest::State => {
+					let response = match Self::decode_state_response(&resp[..]) {
+						Ok(proto) => proto,
+						Err(e) => {
+							debug!(
+								target: LOG_TARGET,
+								"Failed to decode state response from peer {peer_id:?}: {e:?}.",
+							);
+							self.network_service.report_peer(peer_id, rep::BAD_MESSAGE);
+							self.network_service
+								.disconnect_peer(peer_id, self.state_request_protocol_name.clone());
+							return
+						},
+					};
+
+					self.strategy.on_state_response(peer_id, response);
+				},
+				PeerRequest::WarpProof => {
+					error!("Unexpected PeerRequest::WarpProof",);
+				},
+			},
+			Ok(Err(e)) => {
+				debug!(target: LOG_TARGET, "Request to peer {peer_id:?} failed: {e:?}.");
+
+				match e {
+					RequestFailure::Network(OutboundFailure::Timeout) => {
+						self.network_service.report_peer(peer_id, rep::TIMEOUT);
+						self.network_service
+							.disconnect_peer(peer_id, self.state_request_protocol_name.clone());
+					},
+					RequestFailure::Network(OutboundFailure::UnsupportedProtocols) => {
+						self.network_service.report_peer(peer_id, rep::BAD_PROTOCOL);
+						self.network_service
+							.disconnect_peer(peer_id, self.state_request_protocol_name.clone());
+					},
+					RequestFailure::Network(OutboundFailure::DialFailure) => {
+						self.network_service
+							.disconnect_peer(peer_id, self.state_request_protocol_name.clone());
+					},
+					RequestFailure::Refused => {
+						self.network_service.report_peer(peer_id, rep::REFUSED);
+						self.network_service
+							.disconnect_peer(peer_id, self.state_request_protocol_name.clone());
+					},
+					RequestFailure::Network(OutboundFailure::ConnectionClosed) |
+					RequestFailure::NotConnected => {
+						self.network_service
+							.disconnect_peer(peer_id, self.state_request_protocol_name.clone());
+					},
+					RequestFailure::UnknownProtocol => {
+						debug_assert!(false, "Block request protocol should always be known.");
+					},
+					RequestFailure::Obsolete => {
+						debug_assert!(
+							false,
+							"Can not receive `RequestFailure::Obsolete` after dropping the \
+								response receiver.",
+						);
+					},
+				}
+			},
+			Err(oneshot::Canceled) => {
+				trace!(
+					target: LOG_TARGET,
+					"Request to peer {peer_id:?} failed due to oneshot being canceled.",
+				);
+				self.network_service
+					.disconnect_peer(peer_id, self.state_request_protocol_name.clone());
+			},
+		}
+	}
+}

--- a/substrate/client/network/sync/src/fast_sync_engine/syncing_service.rs
+++ b/substrate/client/network/sync/src/fast_sync_engine/syncing_service.rs
@@ -1,0 +1,71 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::types::{ExtendedPeerInfo, SyncStatus};
+
+use futures::channel::oneshot;
+use libp2p::PeerId;
+use sc_utils::mpsc::TracingUnboundedSender;
+use sp_runtime::traits::Block as BlockT;
+
+/// Commands send to `SyncingEngine`
+pub enum ToServiceCommand<B: BlockT> {
+	Start(oneshot::Sender<()>),
+	Status(oneshot::Sender<SyncStatus<B>>),
+	PeersInfo(oneshot::Sender<Vec<(PeerId, ExtendedPeerInfo<B>)>>),
+}
+
+/// Handle for communicating with `SyncingEngine` asynchronously
+#[derive(Clone)]
+pub struct SyncingService<B: BlockT> {
+	tx: TracingUnboundedSender<ToServiceCommand<B>>,
+}
+
+impl<B: BlockT> SyncingService<B> {
+	/// Create new handle
+	pub fn new(tx: TracingUnboundedSender<ToServiceCommand<B>>) -> Self {
+		Self { tx }
+	}
+
+	/// Get peer information.
+	pub async fn peers_info(
+		&self,
+	) -> Result<Vec<(PeerId, ExtendedPeerInfo<B>)>, oneshot::Canceled> {
+		let (tx, rx) = oneshot::channel();
+		let _ = self.tx.unbounded_send(ToServiceCommand::PeersInfo(tx));
+
+		rx.await
+	}
+
+	/// Get sync status
+	///
+	/// Returns an error if `SyncingEngine` has terminated.
+	pub async fn status(&self) -> Result<SyncStatus<B>, oneshot::Canceled> {
+		let (tx, rx) = oneshot::channel();
+		let _ = self.tx.unbounded_send(ToServiceCommand::Status(tx));
+
+		rx.await
+	}
+
+	pub async fn start(&self) -> Result<(), oneshot::Canceled> {
+		let (tx, rx) = oneshot::channel();
+		let _ = self.tx.unbounded_send(ToServiceCommand::Start(tx));
+
+		rx.await
+	}
+}

--- a/substrate/client/network/sync/src/lib.rs
+++ b/substrate/client/network/sync/src/lib.rs
@@ -34,6 +34,7 @@ pub mod block_relay_protocol;
 pub mod block_request_handler;
 pub mod blocks;
 pub mod engine;
+pub mod fast_sync_engine;
 pub mod mock;
 pub mod service;
 pub mod state_request_handler;

--- a/substrate/client/network/sync/src/service/syncing_service.rs
+++ b/substrate/client/network/sync/src/service/syncing_service.rs
@@ -36,6 +36,7 @@ use std::{
 
 /// Commands send to `SyncingEngine`
 pub enum ToServiceCommand<B: BlockT> {
+	NewBestBlockNumber(NumberFor<B>),
 	SetSyncForkRequest(Vec<PeerId>, B::Hash, NumberFor<B>),
 	RequestJustification(B::Hash, NumberFor<B>),
 	ClearJustificationRequests,
@@ -89,6 +90,10 @@ impl<B: BlockT> SyncingService<B> {
 		let _ = self.tx.unbounded_send(ToServiceCommand::NumActivePeers(tx));
 
 		rx.await
+	}
+
+	pub fn new_best_number(&self, number: NumberFor<B>) {
+		let _ = self.tx.unbounded_send(ToServiceCommand::NewBestBlockNumber(number));
 	}
 
 	/// Get best seen block.

--- a/substrate/client/network/sync/src/state_request_handler.rs
+++ b/substrate/client/network/sync/src/state_request_handler.rs
@@ -53,7 +53,7 @@ mod rep {
 }
 
 /// Generates a [`ProtocolConfig`] for the state request protocol, refusing incoming requests.
-pub fn generate_protocol_config<Hash: AsRef<[u8]>>(
+fn generate_protocol_config<Hash: AsRef<[u8]>>(
 	protocol_id: &ProtocolId,
 	genesis_hash: Hash,
 	fork_id: Option<&str>,
@@ -70,7 +70,10 @@ pub fn generate_protocol_config<Hash: AsRef<[u8]>>(
 }
 
 /// Generate the state protocol name from the genesis hash and fork id.
-fn generate_protocol_name<Hash: AsRef<[u8]>>(genesis_hash: Hash, fork_id: Option<&str>) -> String {
+pub fn generate_protocol_name<Hash: AsRef<[u8]>>(
+	genesis_hash: Hash,
+	fork_id: Option<&str>,
+) -> String {
 	let genesis_hash = genesis_hash.as_ref();
 	if let Some(fork_id) = fork_id {
 		format!("/{}/{}/state/2", array_bytes::bytes2hex("", genesis_hash), fork_id)

--- a/substrate/client/network/sync/src/strategy.rs
+++ b/substrate/client/network/sync/src/strategy.rs
@@ -20,7 +20,7 @@
 //! and specific syncing algorithms.
 
 pub mod chain_sync;
-mod state;
+pub(crate) mod state;
 pub mod state_sync;
 pub mod warp;
 

--- a/substrate/client/network/sync/src/strategy.rs
+++ b/substrate/client/network/sync/src/strategy.rs
@@ -200,6 +200,15 @@ where
 		}
 	}
 
+	pub fn update_common_number_for_peers(&mut self, number: NumberFor<B>) {
+		match self {
+			SyncingStrategy::WarpSyncStrategy(_) => {},
+			SyncingStrategy::StateSyncStrategy(_) => {},
+			SyncingStrategy::ChainSyncStrategy(strategy) =>
+				strategy.update_common_number_for_peers(number),
+		}
+	}
+
 	/// Request extra justification.
 	pub fn request_justification(&mut self, hash: &B::Hash, number: NumberFor<B>) {
 		match self {

--- a/substrate/client/network/sync/src/strategy/chain_sync.rs
+++ b/substrate/client/network/sync/src/strategy/chain_sync.rs
@@ -1287,6 +1287,16 @@ where
 		}
 	}
 
+	pub fn update_common_number_for_peers(&mut self, new_common: NumberFor<B>) {
+		for peer in self.peers.values_mut() {
+			if peer.best_number >= new_common {
+				peer.update_common_number(new_common);
+			} else {
+				peer.update_common_number(peer.best_number);
+			}
+		}
+	}
+
 	/// Called when a block has been queued for import.
 	///
 	/// Updates our internal state for best queued block and then goes

--- a/substrate/client/service/src/client/client.rs
+++ b/substrate/client/service/src/client/client.rs
@@ -20,7 +20,7 @@
 
 use super::block_rules::{BlockRules, LookupResult as BlockLookupResult};
 use futures::{FutureExt, StreamExt};
-use log::{error, info, trace, warn};
+use log::{debug, error, info, trace, warn};
 use parking_lot::{Mutex, RwLock};
 use prometheus_endpoint::Registry;
 use rand::Rng;
@@ -55,6 +55,7 @@ use sp_blockchain::{
 };
 use sp_consensus::{BlockOrigin, BlockStatus, Error as ConsensusError};
 
+use codec::Encode;
 use sc_utils::mpsc::{tracing_unbounded, TracingUnboundedSender};
 use sp_core::{
 	storage::{
@@ -85,6 +86,7 @@ use std::{
 	sync::Arc,
 };
 
+use crate::{ClientExt, RawBlockData};
 #[cfg(feature = "test-helpers")]
 use {
 	super::call_executor::LocalCallExecutor, sc_client_api::in_mem, sp_core::traits::CodeExecutor,
@@ -116,6 +118,77 @@ where
 	telemetry: Option<TelemetryHandle>,
 	unpin_worker_sender: TracingUnboundedSender<Block::Hash>,
 	_phantom: PhantomData<RA>,
+}
+
+pub type BlockWeight = u128;
+
+//TODO: make function from the caller
+/// Write the cumulative chain-weight of a block ot aux storage.
+pub(crate) fn write_block_weight<H: Encode, F, R>(
+	block_hash: H,
+	block_weight: BlockWeight,
+	write_aux: F,
+) -> R
+where
+	F: FnOnce(&[(Vec<u8>, &[u8])]) -> R,
+{
+	let key = block_weight_key(block_hash);
+	block_weight.using_encoded(|s| write_aux(&[(key, s)]))
+}
+
+/// The aux storage key used to store the block weight of the given block hash.
+pub fn block_weight_key<H: Encode>(block_hash: H) -> Vec<u8> {
+	(b"block_weight", block_hash).encode()
+}
+
+impl<B, E, Block, RA> ClientExt<Block> for Client<B, E, Block, RA>
+where
+	B: backend::Backend<Block>,
+	E: CallExecutor<Block> + Send + Sync,
+	Block: BlockT,
+	Client<B, E, Block, RA>: ProvideRuntimeApi<Block>,
+	<Client<B, E, Block, RA> as ProvideRuntimeApi<Block>>::Api: CoreApi<Block> + ApiExt<Block>,
+	RA: Sync + Send,
+{
+	fn import_raw_block(&self, raw_block: RawBlockData<Block>) -> Result<(), Error> {
+		let hash = raw_block.hash;
+		let number = *raw_block.header.number();
+		debug!("Importing raw block: {number:?}  - {hash:?} "); // TODO: debug
+
+		let mut import_block = BlockImportParams::new(BlockOrigin::FastSync, raw_block.header);
+		import_block.justifications = raw_block.justifications;
+		import_block.body = raw_block.block_body;
+		import_block.state_action = StateAction::Skip;
+		import_block.finalized = true;
+		import_block.fork_choice = Some(ForkChoiceStrategy::LongestChain);
+		import_block.import_existing = false;
+
+		// Set zero block weight to allow the execution of the following blocks.
+		write_block_weight(hash, 0, |values| {
+			import_block
+				.auxiliary
+				.extend(values.iter().map(|(k, v)| (k.to_vec(), Some(v.to_vec()))))
+		});
+
+		let result = self
+			.lock_import_and_run(|operation| self.apply_block(operation, import_block, None))
+			.map_err(|e| {
+				error!("Error during importing of the raw block: {}", e);
+				ConsensusError::ClientImport(e.to_string())
+			})?;
+
+		debug!("Raw block imported: {number:?}  - {hash:?}. Result: {result:?}"); // TODO: debug
+
+		Ok(())
+	}
+
+	fn clear_block_gap(&self) {
+		self.backend.blockchain().clear_block_gap();
+	}
+
+	fn update_block_gap(&self, start: NumberFor<Block>, end: NumberFor<Block>) {
+		self.backend.blockchain().update_block_gap(start, end);
+	}
 }
 
 /// Used in importing a block, where additional changes are made after the runtime
@@ -335,10 +408,17 @@ where
 
 			if let Some(ref notification) = import_notification {
 				if let Err(err) = self.backend.pin_block(notification.hash) {
-					error!(
-						"Unable to pin block for import notification. hash: {}, Error: {}",
-						notification.hash, err
-					);
+					// Fast-sync block import has no state yet.
+					let block_pin_disabled = import_notification
+						.as_ref()
+						.map(|notification| notification.origin == BlockOrigin::FastSync)
+						.unwrap_or_default();
+					if !block_pin_disabled {
+						error!(
+							"Unable to pin block for import notification. hash: {}, number: {}, Error: {}",
+							notification.hash, notification.header.number(), err
+						);
+					}
 				};
 			}
 
@@ -619,7 +699,10 @@ where
 		let make_notifications = match origin {
 			BlockOrigin::NetworkBroadcast | BlockOrigin::Own | BlockOrigin::ConsensusBroadcast =>
 				true,
-			BlockOrigin::Genesis | BlockOrigin::NetworkInitialSync | BlockOrigin::File => false,
+			BlockOrigin::Genesis |
+			BlockOrigin::NetworkInitialSync |
+			BlockOrigin::File |
+			BlockOrigin::FastSync => false,
 		};
 
 		let storage_changes = match storage_changes {
@@ -1747,6 +1830,9 @@ where
 		&mut self,
 		mut import_block: BlockImportParams<Block>,
 	) -> Result<ImportResult, Self::Error> {
+		//		info!("Client import block: {} {:?}",  import_block.header.number(),
+		// import_block.header.hash());
+
 		let span = tracing::span!(tracing::Level::DEBUG, "import_block");
 		let _enter = span.enter();
 
@@ -1758,6 +1844,9 @@ where
 				PrepareStorageChangesResult::Discard(res) => return Ok(res),
 				PrepareStorageChangesResult::Import(storage_changes) => storage_changes,
 			};
+
+		//		info!("Before lock_import_and_run: {} {:?}",  import_block.header.number(),
+		// import_block.header.hash());
 
 		self.lock_import_and_run(|operation| {
 			self.apply_block(operation, import_block, storage_changes)

--- a/substrate/primitives/blockchain/src/backend.rs
+++ b/substrate/primitives/blockchain/src/backend.rs
@@ -255,6 +255,10 @@ pub trait Backend<Block: BlockT>:
 	}
 
 	fn block_indexed_body(&self, hash: Block::Hash) -> Result<Option<Vec<Vec<u8>>>>;
+
+	fn clear_block_gap(&self);
+
+	fn update_block_gap(&self, start: NumberFor<Block>, end: NumberFor<Block>);
 }
 
 /// Blockchain info

--- a/substrate/primitives/consensus/common/src/lib.rs
+++ b/substrate/primitives/consensus/common/src/lib.rs
@@ -69,6 +69,8 @@ pub enum BlockOrigin {
 	Own,
 	/// Block was imported from a file.
 	File,
+	/// Block was imported using fast sync.
+	FastSync,
 }
 
 /// Environment for a Consensus instance.


### PR DESCRIPTION
This PR adds support for the upcoming fast-sync algorithm from `subspace-node`.

Changes:

- add a method for "raw-import" block which bypasses the majority of checks and execution
- add fast-sync-engine - a simplified version of the sync-engine which enables access to existing state-sync strategy
- add operations for removing the block gap metadata that Substrate calculates when we insert not the sequential block
- expose currently connected peers (open peers)
- add NewBestBlockNumber event to update common block number with connected peers.
