### PR TITLE
Fast sync changes

### DIFF
--- a/substrate/client/api/src/in_mem.rs
+++ b/substrate/client/api/src/in_mem.rs
@@ -448,7 +448,7 @@ impl<Block: BlockT> blockchain::Backend<Block> for Blockchain<Block> {
 		unimplemented!("Not supported by the in-mem backend.")
 	}
 
-	fn clear_block_gap(&self) {
+	fn clear_block_gap(&self) -> sp_blockchain::Result<()> {
 		unimplemented!("Not supported by the in-mem backend.")
 	}
 }

--- a/substrate/client/db/src/lib.rs
+++ b/substrate/client/db/src/lib.rs
@@ -804,9 +804,16 @@ impl<Block: BlockT> sc_client_api::blockchain::Backend<Block> for BlockchainDb<B
 		}
 	}
 
-	fn clear_block_gap(&self) {
+	fn clear_block_gap(&self) -> ClientResult<()> {
 		debug!(target: "sync", "Clear block gap.");
+
+		let mut transaction = Transaction::new();
+		transaction.remove(columns::META, meta_keys::BLOCK_GAP);
+		self.db.commit(transaction)?;
+
 		self.update_block_gap(None);
+
+		Ok(())
 	}
 }
 

--- a/substrate/client/network/src/service.rs
+++ b/substrate/client/network/src/service.rs
@@ -743,21 +743,6 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 		rx.await.map_err(|_| ())
 	}
 
-	/// Returns a collection of currently connected (open) peers.
-	pub async fn connected_peers(&self) -> Result<Vec<PeerId>, ()> {
-		let (tx, rx) = oneshot::channel();
-
-		let _ = self
-			.to_worker
-			.unbounded_send(ServiceToWorkerMsg::ConnectedPeers { pending_response: tx });
-
-		match rx.await {
-			Ok(v) => Ok(v),
-			// The channel can only be closed if the network worker no longer exists.
-			Err(_) => Err(()),
-		}
-	}
-
 	/// Utility function to extract `PeerId` from each `Multiaddr` for peer set updates.
 	///
 	/// Returns an `Err` if one of the given addresses is invalid or contains an
@@ -1188,9 +1173,6 @@ enum ServiceToWorkerMsg {
 	NetworkState {
 		pending_response: oneshot::Sender<Result<NetworkState, RequestFailure>>,
 	},
-	ConnectedPeers {
-		pending_response: oneshot::Sender<Vec<PeerId>>,
-	},
 	DisconnectPeer(PeerId, ProtocolName),
 }
 
@@ -1333,19 +1315,7 @@ where
 				.behaviour_mut()
 				.user_protocol_mut()
 				.disconnect_peer(&who, protocol_name),
-			ServiceToWorkerMsg::ConnectedPeers { pending_response } => {
-				let _ = pending_response.send(self.connected_peers());
-			},
 		}
-	}
-
-	fn connected_peers(&self) -> Vec<PeerId> {
-		self.network_service
-			.behaviour()
-			.user_protocol()
-			.open_peers()
-			.cloned()
-			.collect::<Vec<_>>()
 	}
 
 	/// Process the next event coming from `Swarm`.

--- a/substrate/client/service/src/client/client.rs
+++ b/substrate/client/service/src/client/client.rs
@@ -123,26 +123,10 @@ where
 	B: backend::Backend<Block>,
 	E: CallExecutor<Block> + Send + Sync,
 	Block: BlockT,
-	Client<B, E, Block, RA>: ProvideRuntimeApi<Block>,
-	<Client<B, E, Block, RA> as ProvideRuntimeApi<Block>>::Api: CoreApi<Block> + ApiExt<Block>,
 	RA: Sync + Send,
 {
-	/// Apply a checked and validated block to an operation.
-	fn apply_block(
-		&self,
-		operation: &mut ClientImportOperation<Block, B>,
-		import_block: BlockImportParams<Block>,
-		storage_changes: Option<sc_consensus::StorageChanges<Block>>,
-	) -> sp_blockchain::Result<ImportResult>
-	where
-		Self: ProvideRuntimeApi<Block>,
-		<Self as ProvideRuntimeApi<Block>>::Api: CoreApi<Block> + ApiExt<Block>,
-	{
-		self.apply_block(operation, import_block, storage_changes)
-	}
-
-	fn clear_block_gap(&self) {
-		self.backend.blockchain().clear_block_gap();
+	fn clear_block_gap(&self) -> sp_blockchain::Result<()> {
+		self.backend.blockchain().clear_block_gap()
 	}
 }
 

--- a/substrate/client/service/src/lib.rs
+++ b/substrate/client/service/src/lib.rs
@@ -41,8 +41,7 @@ use futures::{pin_mut, FutureExt, StreamExt};
 use jsonrpsee::RpcModule;
 use log::{debug, error, warn};
 use sc_client_api::{
-	backend, blockchain::HeaderBackend, BlockBackend, BlockchainEvents, ClientImportOperation,
-	ProofProvider,
+	backend, blockchain::HeaderBackend, BlockBackend, BlockchainEvents, ProofProvider,
 };
 use sc_network::{
 	config::MultiaddrWithPeerId, NetworkBlock, NetworkPeers, NetworkStateInfo, PeerId,
@@ -78,7 +77,6 @@ pub use sc_chain_spec::{
 	Properties, RuntimeGenesis,
 };
 
-use sc_consensus::BlockImportParams;
 pub use sc_consensus::ImportQueue;
 pub use sc_executor::NativeExecutionDispatch;
 pub use sc_network_sync::WarpSyncParams;
@@ -102,15 +100,8 @@ pub struct RpcHandlers(Arc<RpcModule<()>>);
 
 /// Provides extended functions for `Client` to enable fast-sync.
 pub trait ClientExt<Block: BlockT, B: backend::Backend<Block>> {
-	/// Apply a checked and validated block to an operation.
-	fn apply_block(
-		&self,
-		operation: &mut ClientImportOperation<Block, B>,
-		import_block: BlockImportParams<Block>,
-		storage_changes: Option<sc_consensus::StorageChanges<Block>>,
-	) -> sp_blockchain::Result<sc_consensus::ImportResult>;
 	/// Clear block gap after initial block insertion.
-	fn clear_block_gap(&self);
+	fn clear_block_gap(&self) -> sp_blockchain::Result<()>;
 }
 
 impl RpcHandlers {

--- a/substrate/primitives/blockchain/src/backend.rs
+++ b/substrate/primitives/blockchain/src/backend.rs
@@ -257,7 +257,7 @@ pub trait Backend<Block: BlockT>:
 	fn block_indexed_body(&self, hash: Block::Hash) -> Result<Option<Vec<Vec<u8>>>>;
 
 	/// Clears the block gap from DB after the fast-sync.
-	fn clear_block_gap(&self);
+	fn clear_block_gap(&self) -> Result<()>;
 }
 
 /// Blockchain info


### PR DESCRIPTION
This PR updates fast-sync API:
- remove `connected_peers` method
- update `clear_block_gap` with removing the gap from DB
- remove `apply_block` from exported API